### PR TITLE
Use decorator module to preserve wrapped function metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ def f3():
     pass
 ```
 
+It is safe to reuse the same once created decorator instance on a different
+functions. 
+
+```python
+my_decorator_500 = my_decorator(arg2=500)
+
+@my_decorator_500
+def f1():
+    print('f1')
+
+@my_decorator_500
+def f2():
+    print('f2')
+
+f1()
+f2()
+```
+
 
 ## Authors
 

--- a/decoratorium.py
+++ b/decoratorium.py
@@ -1,4 +1,7 @@
 from collections import Callable
+from functools import partial
+
+from decorator import decorate
 
 
 __all__ = ['decoratorium']
@@ -18,20 +21,20 @@ class Decoratorium:
         return self
 
     def __call__(self, func):
-        """ An actual decorator.
+        """ Builds decorated function.
         """
-        self.func = func
-        return self.wrapper
+        return decorate(func, self.wrapper)
 
     def __init__(self, *args, **kwargs):
         """ Allows to catch decorator arguments via `@decorator(args)` syntax.
         """
         pass
 
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self, func, *args, **kwargs):
         """ A wrapper interface to be implemented.
 
-        Has access to the decorated function via `self.func`.
+        Uses decorate module approach to have `func` being passed explicitly.
+        This allows to reuse the same decorator class on several functions.
         """
         return NotImplemented
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     ],
     keywords='python decorator class klass',
     py_modules=['decoratorium'],
+    install_requires=['decorator'],
     extras_require={
         'test': ['pytest'],
     },

--- a/tests/test_decoratorium.py
+++ b/tests/test_decoratorium.py
@@ -12,9 +12,9 @@ def decorator_klass():
             self.arg1 = arg1
             self.arg2 = arg2
 
-        def wrapper(self, *args, **kwargs):
-            result = self.func(*args, **kwargs)
-            return self.arg1, self.arg2, self.func, args, kwargs, result
+        def wrapper(self, func, *args, **kwargs):
+            result = func(*args, **kwargs)
+            return self.arg1, self.arg2, func, args, kwargs, result
 
     return test_decorator
 
@@ -70,4 +70,51 @@ def test_explicit_args_mixed_decorator(decorator_klass):
         (300,),
         {'bar': 400},
         ((300,), {'bar': 400},),
+    )
+
+
+def test_metadata(decorator_klass):
+
+    # @decorator_klass
+    def foo(*args, **kwargs):
+        """ Function `foo` docstring.
+        """
+        return args, kwargs
+    foo.bar = 'fubar'
+
+    dfoo = decorator_klass(foo)
+
+    assert dfoo.__name__ == foo.__name__
+    assert dfoo.__doc__ == foo.__doc__
+    assert dfoo.bar == foo.bar
+
+
+def test_decorator_reuse(decorator_klass):
+
+    decorator_klass_500 = decorator_klass(arg2=500)
+
+    def foo1(*args, **kwargs):
+        return 500
+
+    def foo2(*args, **kwargs):
+        return 600
+
+    dfoo1 = decorator_klass_500(foo1)
+    dfoo2 = decorator_klass_500(foo2)
+
+    assert dfoo1() == (
+        100,
+        500,
+        foo1,
+        (),
+        {},
+        500,
+    )
+    assert dfoo2() == (
+        100,
+        500,
+        foo2,
+        (),
+        {},
+        600,
     )


### PR DESCRIPTION
Allow to reuse decorator instanse on several independent functions.
Backward incompatible!
Fix#2